### PR TITLE
Исправил кликабельность навигации

### DIFF
--- a/src/sass/_menu.scss
+++ b/src/sass/_menu.scss
@@ -18,6 +18,7 @@
   display: flex;
   position: relative;
   padding-top: 7px;
+  z-index: 1;
 
   @media screen and (min-width: 768px) {
     padding-top: 27px;


### PR DESCRIPTION
При 100% экране блок изображения пончиков перекрывало часть меню. Из-за этого не нажимались кнопки. Поставил на .navigation - z-index: 1. Теперь все ок.